### PR TITLE
make initial byes process more efficient

### DIFF
--- a/gatherling/models/Entry.php
+++ b/gatherling/models/Entry.php
@@ -29,7 +29,7 @@ class Entry
         }
     }
 
-    public static function getActivePlayersWithInitialByes($eventname, $currentround=1)
+    public static function getActivePlayersWithInitialByes($eventname, $currentround = 1)
     {
         $db = Database::getConnection();
         $stmt = $db->prepare('SELECT e.player
@@ -55,7 +55,7 @@ class Entry
             $entries[] = new Entry($eventname, $name);
         }
 
-        return $entries;   
+        return $entries;
     }
 
     // TODO: remove ignore functionality

--- a/gatherling/models/Entry.php
+++ b/gatherling/models/Entry.php
@@ -29,6 +29,35 @@ class Entry
         }
     }
 
+    public static function getActivePlayersWithInitialByes($eventname, $currentround=1)
+    {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('SELECT e.player
+            FROM entries e
+            JOIN standings s ON e.event = s.event
+            WHERE e.event = ?
+            AND s.active = 1
+            AND e.deck IS NOT NULL
+            AND e.initial_byes >= ?
+            GROUP BY player');
+        $stmt->bind_param('sd', $eventname, $currentround);
+        $entries = [];
+        $playernames = [];
+        $playername = '';
+        $stmt->execute();
+        $stmt->bind_result($playername);
+        while ($stmt->fetch()) {
+            $playernames[] = $playername;
+        }
+        $stmt->close();
+
+        foreach ($playernames as $name) {
+            $entries[] = new Entry($eventname, $name);
+        }
+
+        return $entries;   
+    }
+
     // TODO: remove ignore functionality
     public function __construct($eventname, $playername)
     {

--- a/gatherling/models/Event.php
+++ b/gatherling/models/Event.php
@@ -660,26 +660,6 @@ class Event
         return $entries;
     }
 
-    public function getActiveEntriesWithInitialByes()
-    {
-        $players = $this->getPlayers();
-
-        $entries = [];
-        foreach ($players as $player) {
-            $entry = new Entry($this->name, $player);
-            if (is_null($entry->deck)) {
-                continue;
-            }
-            $standings = new Standings($this->name, $player);
-            if ($entry->deck->isValid() && $entry->initial_byes > 0 && $standings->active) {
-                //$entries[] = new Entry($this->name, $player);
-                $entries[] = $entry;
-            }
-        }
-
-        return $entries;
-    }
-
     public function dropInvalidEntries()
     {
         $players = $this->getPlayers();
@@ -1241,11 +1221,8 @@ class Event
 
         $this->skipInvalidDecks();
 
-        $entries = $this->getActiveEntriesWithInitialByes();
+        $entries = Entry::getActivePlayersWithInitialByes($this->name, $this->current_round + 1);
         foreach ($entries as $entry) {
-            if ($entry->initial_byes < 1 || ($entry->initial_byes < $this->current_round + 1)) {
-                continue;
-            }
             $player1 = new Standings($this->name, $entry->player->name);
             $this->award_bye($player1);
             $player1->matched = 1;


### PR DESCRIPTION
Reducing unnecessary database calling to speed the process up. So instead of looping through every players and checking whether they have initial byes or not, we get the data of players having initial byes directly from database.