### PR TITLE
Remove extra confirmation window

### DIFF
--- a/gatherling/report.php
+++ b/gatherling/report.php
@@ -10,10 +10,6 @@ if ($player == null) {
     if (isset($_POST['action'])) {
         if ($_POST['action'] == 'finalize_result') {
             // write results to matches table
-            $drop = false;
-            // if (isset($_POST['drop'])) {
-            //     $drop = $_POST['drop'] == 'Y';
-            // }
             $drop = isset($_POST['drop']);
             if ($drop) {
                 $match = new Match($_POST['match_id']);
@@ -81,16 +77,6 @@ print_header('Player Control Panel');
     League_print_submit_resultForm($_REQUEST['event'], $_REQUEST['round'], $player, $_REQUEST['subevent']);
     break;
 
-    // case 'verify_result':
-    // if (isset($_POST['report'])) {
-    //     $drop = (isset($_POST['drop'])) ? 'Y' : 'N';
-    //     print_verify_resultForm($_POST['report'], $_POST['match_id'], $_POST['player'], $drop, 0, 0);
-    // } else {
-    //     print_submit_resultForm($_REQUEST['match_id']);
-    // }
-    // break;
-
-    // todo: Fold this into the above case
     case 'verify_league_result':
     print_verify_resultForm($_REQUEST['report'], $_REQUEST['match_id'], $_REQUEST['player'], 'N', $_REQUEST['opponent'], $_REQUEST['event']);
     break;
@@ -176,7 +162,7 @@ function print_submit_resultForm($match_id, $drop = false)
     echo "<center><h3>Report Game Results</h3>
     Enter results for <em>$event->name</em> round $event->current_round vs. $oppplayer->name</center>\n";
 
-    echo "<form action=\"report.php\" method=\"post\" onsubmit=\"return check_drop(this);\">\n";
+    echo "<form action=\"report.php\" method=\"post\" onsubmit=\"return verify_input(this);\">\n";
     echo "<input name=\"action\" type=\"hidden\" value=\"finalize_result\" />\n";
     echo "<input name=\"mode\" type=\"hidden\" value=\"submit_result\" />\n";
     echo "<input name=\"match_id\" type=\"hidden\" value=\"{$match_id}\" />\n";
@@ -297,7 +283,7 @@ function print_verify_resultForm($report, $match_id, $player, $drop, $opponent, 
 ?>
 
 <script>
-function check_drop(form) {
+function verify_input(form) {
     //Check if the player wants to drop
     if(form[9].checked) {
         return confirm('Are you sure you want to drop? This cannot be undone.');

--- a/gatherling/report.php
+++ b/gatherling/report.php
@@ -285,16 +285,16 @@ function print_verify_resultForm($report, $match_id, $player, $drop, $opponent, 
 <script>
 function verify_input(form) {
     //Check if the player wants to drop
-    if(form[9].checked) {
+    if($("input[name='drop']").is(':checked')) {
         return confirm('Are you sure you want to drop? This cannot be undone.');
     }
 
     //Check if no result being selected
-    if(!form[5].checked && !form[6].checked && !form[7].checked && !form[8].checked) {
+    if (!$("input[name='report']:checked").val()) {
         alert('No result being selected. Please choose a result.');
         return false;
     }
-    
+
     return true;
 }
 </script>

--- a/gatherling/report.php
+++ b/gatherling/report.php
@@ -11,9 +11,10 @@ if ($player == null) {
         if ($_POST['action'] == 'finalize_result') {
             // write results to matches table
             $drop = false;
-            if (isset($_POST['drop'])) {
-                $drop = $_POST['drop'] == 'Y';
-            }
+            // if (isset($_POST['drop'])) {
+            //     $drop = $_POST['drop'] == 'Y';
+            // }
+            $drop = isset($_POST['drop']);
             if ($drop) {
                 $match = new Match($_POST['match_id']);
                 $eventname = $match->getEventNamebyMatchid();
@@ -80,14 +81,14 @@ print_header('Player Control Panel');
     League_print_submit_resultForm($_REQUEST['event'], $_REQUEST['round'], $player, $_REQUEST['subevent']);
     break;
 
-    case 'verify_result':
-    if (isset($_POST['report'])) {
-        $drop = (isset($_POST['drop'])) ? 'Y' : 'N';
-        print_verify_resultForm($_POST['report'], $_POST['match_id'], $_POST['player'], $drop, 0, 0);
-    } else {
-        print_submit_resultForm($_REQUEST['match_id']);
-    }
-    break;
+    // case 'verify_result':
+    // if (isset($_POST['report'])) {
+    //     $drop = (isset($_POST['drop'])) ? 'Y' : 'N';
+    //     print_verify_resultForm($_POST['report'], $_POST['match_id'], $_POST['player'], $drop, 0, 0);
+    // } else {
+    //     print_submit_resultForm($_REQUEST['match_id']);
+    // }
+    // break;
 
     // todo: Fold this into the above case
     case 'verify_league_result':
@@ -175,9 +176,11 @@ function print_submit_resultForm($match_id, $drop = false)
     echo "<center><h3>Report Game Results</h3>
     Enter results for <em>$event->name</em> round $event->current_round vs. $oppplayer->name</center>\n";
 
-    echo "<form action=\"report.php\" method=\"post\">\n";
-    echo "<input name=\"mode\" type=\"hidden\" value=\"verify_result\" />\n";
+    echo "<form action=\"report.php\" method=\"post\" onsubmit=\"return check_drop(this);\">\n";
+    echo "<input name=\"action\" type=\"hidden\" value=\"finalize_result\" />\n";
+    echo "<input name=\"mode\" type=\"hidden\" value=\"submit_result\" />\n";
     echo "<input name=\"match_id\" type=\"hidden\" value=\"{$match_id}\" />\n";
+    echo "<input name=\"opponent\" type=\"hidden\" value=\"0\" />\n";
     echo "<input name=\"player\" type=\"hidden\" value=\"{$letter}\" />\n";
     echo '<table class="form">';
     echo "<tr><td><input type='radio' name='report' value='W20' /> I won the match 2-0</td> </tr>";
@@ -292,3 +295,20 @@ function print_verify_resultForm($report, $match_id, $player, $drop, $opponent, 
     echo "<div class=\"clear\"> </div>\n";
 }
 ?>
+
+<script>
+function check_drop(form) {
+    //Check if the player wants to drop
+    if(form[9].checked) {
+        return confirm('Are you sure you want to drop? This cannot be undone.');
+    }
+
+    //Check if no result being selected
+    if(!form[5].checked && !form[6].checked && !form[7].checked && !form[8].checked) {
+        alert('No result being selected. Please choose a result.');
+        return false;
+    }
+    
+    return true;
+}
+</script>1

--- a/gatherling/report.php
+++ b/gatherling/report.php
@@ -297,4 +297,4 @@ function verify_input(form) {
     
     return true;
 }
-</script>1
+</script>


### PR DESCRIPTION
fixes #68 

1. For non-league round, if the player reports a result and don't wish to drop, there is no additional confirmation
2. For case number 1 but the player wish to drop, a confirmation pop-up will show to make sure they wish to drop, before processing the result
3. Add a line to catch case when a player hit Submit without choosing a result