### PR TITLE
Larger file upload for cardset

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ WORKDIR /var/www/html/
 COPY ./gatherling /var/www/html/
 COPY --from=compose /restore/vendor /var/www/html/vendor
 
+# Let us upload larger files than 2M so that we can install cardsets from MTGJSON
+RUN printf 'upload_max_filesize = 128M\n' >>/usr/local/etc/php/conf.d/uploads.ini
+
 ## Expose used ports
 EXPOSE 80
 


### PR DESCRIPTION
- Increase max upload file size to make insert card set work again
- Revert "Increase max upload file size to make insert card set work again"
- Allow larger PHP file uploads to fix cardset uploader
