### PR TITLE
Order series in dropdowns alphabetically instead of by number of events

### DIFF
--- a/gatherling/models/Player.php
+++ b/gatherling/models/Player.php
@@ -1311,7 +1311,7 @@ class Player
             return Series::allNames();
         }
         $db = Database::getConnection();
-        $stmt = $db->prepare('SELECT series FROM series_organizers WHERE player = ?');
+        $stmt = $db->prepare('SELECT series FROM series_organizers WHERE player = ? ORDER BY series');
         $stmt->bind_param('s', $this->name);
         $stmt->execute();
         $series = [];

--- a/gatherling/models/Series.php
+++ b/gatherling/models/Series.php
@@ -284,9 +284,7 @@ class Series
                           LEFT JOIN events
                           ON events.series = series.name
                           GROUP BY series.name
-                          ORDER BY isactive
-                          DESC, count(events.name)
-                          DESC, name');
+                          ORDER BY series.name');
         $stmt->execute();
         $stmt->bind_result($onename);
         $names = [];


### PR DESCRIPTION
It may once have been useful to see the popular series at the top but now that there are a hundred or so an alphabetized list is better.
