### PR TITLE
Don't pair folks with invalid decklists when setting up later rounds

### DIFF
--- a/gatherling/models/Event.php
+++ b/gatherling/models/Event.php
@@ -1582,7 +1582,7 @@ class Event
                 }
 
                 if ($structure != 'League' && $this->active === 1) {
-                    $this->pairCurrentRound();
+                    $this->pairCurrentRound(true);
                 }
             }
         }
@@ -1698,7 +1698,7 @@ class Event
         $this->save();
         $this->recalculateScores('Swiss');
         Standings::updateStandings($this->name, $this->mainid, 1);
-        $this->pairCurrentRound();
+        $this->pairCurrentRound(true);
     }
 
     public function assignMedals()


### PR DESCRIPTION
We were getting people late entering for r2 of a tournament but not entering a decklist. They were getting paired for r2.
