### PR TITLE
Add back two missing checkboxes on eventForm

### DIFF
--- a/gatherling/views/eventForm.mustache
+++ b/gatherling/views/eventForm.mustache
@@ -111,6 +111,8 @@
                     </tr>
                 {{/currentlyEditing}}
                 {{#currentlyEditing}}
+                    {{#finalizeEventCheckbox}}{{> checkboxInput}}{{/finalizeEventCheckbox}}
+                    {{#eventActiveCheckbox}}{{> checkboxInput}}{{/eventActiveCheckbox}}
                     <tr>
                         <th>Current Round</th>
                         <td>


### PR DESCRIPTION
The args were being generated but the template did not have the partial
reference to actually render them. Oops.
