### PR TITLE
Let calls to DB::value indicate if the value not being present is ok or not

### DIFF
--- a/gatherling/Auth/Session.php
+++ b/gatherling/Auth/Session.php
@@ -40,7 +40,7 @@ class Session
             AND
                 expiry >= NOW()';
         $args = ['token' => $token];
-        $details = DB::value($sql, $args);
+        $details = DB::value($sql, $args, true);
         return $details ? json_decode($details, true) : [];
     }
 

--- a/gatherling/Data/DB.php
+++ b/gatherling/Data/DB.php
@@ -90,13 +90,16 @@ class DB
         });
     }
 
-    public static function value(string $sql, array $params = []): mixed
+    public static function value(string $sql, array $params = [], bool $missingOk = false): mixed
     {
-        return self::_execute($sql, $params, function ($sql, $params) {
+        return self::_execute($sql, $params, function ($sql, $params) use ($missingOk) {
             $stmt = self::connect()->pdo->prepare($sql);
             $stmt->execute($params);
-
-            return $stmt->fetchColumn();
+            $result = $stmt->fetch(PDO::FETCH_NUM);
+            if ($result === false && !$missingOk) {
+                throw new DatabaseException("Failed to fetch value for $sql");
+            }
+            return $result[0] ?? null;
         });
     }
 

--- a/gatherling/Models/Player.php
+++ b/gatherling/Models/Player.php
@@ -3,6 +3,7 @@
 namespace Gatherling\Models;
 
 use Exception;
+use Gatherling\Data\DB;
 
 class Player
 {
@@ -106,19 +107,11 @@ class Player
             return false;
         }
         $username = self::sanitizeUsername($username);
-
-        $db = Database::getConnection();
-        $stmt = $db->prepare('SELECT password FROM players WHERE name = ?');
-        $stmt->bind_param('s', $username);
-        $stmt->execute();
-        $stmt->bind_result($srvpass);
-        if (!$stmt->fetch()) {
+        $srvpass = DB::value('SELECT password FROM players WHERE name = :name', ['name' => $username], true);
+        if ($srvpass === null) {
             return false;
         }
-        $stmt->close();
-
         $hashpwd = hash('sha256', $password);
-
         return strcmp($srvpass, $hashpwd) == 0;
     }
 

--- a/tests/Data/DBTest.php
+++ b/tests/Data/DBTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gatherling\Tests\Data;
 
 use Gatherling\Data\DB;
+use Gatherling\Exceptions\DatabaseException;
 use Gatherling\Tests\DatabaseCase;
 
 class DBTest extends DatabaseCase
@@ -44,6 +45,10 @@ class DBTest extends DatabaseCase
         $this->assertEquals('Test1', $value);
         $value = DB::value('SELECT id FROM test_table WHERE id = 1');
         $this->assertEquals(1, $value);
+        $value = DB::value('SELECT id FROM test_table WHERE id = 9999', [], true);
+        $this->assertNull($value);
+        $this->expectException(DatabaseException::class);
+        DB::value('SELECT id FROM test_table WHERE id = 9999');
     }
 
     public function testCommit()


### PR DESCRIPTION
If it's not ok (default) then throw a DatabaseException. If it is ok then return null when the query gets no result.

Note: there is no way to differentiate between "found and was NULL" and "not found" but that's probably better than the previous situation of not being able to tell if it was "found and is FALSE". If we need the former we'll have to complicate this later.

Included - change to checkPassword which uses the new facility and thus avoids using a variable that might be null.
