### PR TITLE
Make sessions.details very large to accommodate large session data

### DIFF
--- a/gatherling/Data/sql/migrations/56.sql
+++ b/gatherling/Data/sql/migrations/56.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sessions MODIFY details LONGTEXT


### PR DESCRIPTION
The error log on prod tells me we've tried to put stuff longer than TEXT in here
- something to do with "search_results" being stored in the session.
