### PR TITLE
Further modernizing of Gatherling codebase

### DIFF
--- a/gatherling/Data/sql/migrations/61.sql
+++ b/gatherling/Data/sql/migrations/61.sql
@@ -1,0 +1,6 @@
+-- Tighten up the cardset table. These things are already true.
+ALTER TABLE cardsets MODIFY type ENUM('Core','Block','Extra') NOT NULL;
+ALTER TABLE cardsets MODIFY standard_legal TINYINT(1) NOT NULL;
+ALTER TABLE cardsets MODIFY modern_legal TINYINT(1) NOT NULL;
+-- Tighten up the cards table.
+ALTER TABLE cards MODIFY rarity VARCHAR(40) NOT NULL;

--- a/gatherling/Models/CardDto.php
+++ b/gatherling/Models/CardDto.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gatherling\Models;
+
+class CardDto extends Dto
+{
+    public int $id;
+    public string $name;
+    public string $type;
+    public string $rarity;
+    public string $scryfallId;
+    public bool $is_changeling;
+    public string $cardset;
+    public int $count;
+}

--- a/gatherling/Models/CardSet.php
+++ b/gatherling/Models/CardSet.php
@@ -78,7 +78,7 @@ class CardSet
             Log::info("Inserting card set ($set, $releaseDate, $setType)...");
 
             // Insert the card set
-            $stmt = $database->prepare('INSERT INTO cardsets(released, name, type, code) values(?, ?, ?, ?)');
+            $stmt = $database->prepare('INSERT INTO cardsets(released, name, type, code, standard_legal, modern_legal) values(?, ?, ?, ?, 0, 0)');
             $stmt->bind_param('ssss', $releaseDate, $set, $setType, $data->code);
 
             if (!$stmt->execute()) {

--- a/gatherling/Models/CardSetDto.php
+++ b/gatherling/Models/CardSetDto.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gatherling\Models;
+
+class CardSetDto extends Dto
+{
+    public string $name;
+    public ?string $code;
+    public string $released;
+    public string $type;
+    public ?string $last_updated;
+    public int $count;
+    public bool $standard_legal;
+    public bool $modern_legal;
+}

--- a/gatherling/Models/Deck.php
+++ b/gatherling/Models/Deck.php
@@ -589,7 +589,7 @@ class Deck
         } else {
             $stmt = $db->prepare('UPDATE decks SET archetype = ?, name = ?, format = ?, tribe = ?, deck_colors = ?, notes = ? WHERE id = ?');
             if (!$stmt) {
-                echo $db->error;
+                throw new \Exception($db->error);
             }
             $stmt->bind_param('ssssssd', $this->archetype, $this->name, $this->format, $this->tribe, $this->deck_color_str, $this->notes, $this->id);
             if (!$stmt->execute()) {

--- a/gatherling/Models/Event.php
+++ b/gatherling/Models/Event.php
@@ -1530,7 +1530,6 @@ class Event
 
         if ($matches_remaining > 0) {
             // Nothing to do yet
-            //echo "There are still {$matches_remaining} unresolved matches";
             return;
         } else {
             if ($this->current_round > $this->mainrounds) {
@@ -1542,7 +1541,6 @@ class Event
             if ($this->current_round == $current_round) {
                 $matches2 = $this->getRoundMatches($this->current_round);
                 foreach ($matches2 as $match) {
-                    //echo "about to update scores";
                     $match->updateScores($structure);
                 }
                 if (strpos($structure, 'Swiss') === 0) {
@@ -1585,7 +1583,6 @@ class Event
         $this->resetScores();
         $matches2 = $this->getRoundMatches('ALL');
         foreach ($matches2 as $match) {
-            //echo "about to update scores";
             $match->fixScores($structure);
         }
     }

--- a/gatherling/Models/Matchup.php
+++ b/gatherling/Models/Matchup.php
@@ -444,7 +444,6 @@ class Matchup
                 $playera_standing->matches_played++;
                 $playera_standing->games_played += ($this->playera_wins + $this->playera_losses);
                 $playera_standing->games_won += $this->playera_wins;
-                //echo "****playeragameswon".$playera_standing->games_won;
                 $playerb_standing->matches_played++;
                 $playerb_standing->games_played += $this->playera_wins + $this->playera_losses;
                 $playerb_standing->games_won += $this->playerb_wins;

--- a/gatherling/Models/Series.php
+++ b/gatherling/Models/Series.php
@@ -472,7 +472,7 @@ class Series
                                                   loss_pts=?, bye_pts=?, must_decklist=?, cutoff_ord=?, master_link=?,
                                                   format=?');
         if (!$stmt) {
-            echo $db->error;
+            throw new \Exception($db->error);
         }
         $stmt->bind_param(
             'sdddddddddddddssddddddddddddss',

--- a/gatherling/Views/Components/CheckboxInput.php
+++ b/gatherling/Views/Components/CheckboxInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gatherling\Views\Components;
+
+class CheckboxInput extends Component
+{
+    public function __construct(public string $label, public string $name, public bool $isChecked = false, public ?string $reminderText = null)
+    {
+        parent::__construct('partials/checkboxInput');
+    }
+}

--- a/gatherling/Views/Components/EditCard.php
+++ b/gatherling/Views/Components/EditCard.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gatherling\Views\Components;
+
+use Gatherling\Data\DB;
+use Gatherling\Models\Format;
+use Gatherling\Models\CardDto;
+use Gatherling\Views\Components\CheckboxInput;
+
+class EditCard extends Component
+{
+    public string $cardSet;
+    public TextInput $nameInput;
+    public TextInput $typelineInput;
+    public TextInput $rarityInput;
+    public TextInput $scryfallIdInput;
+    public CheckboxInput $isChangelingInput;
+    public string $creatureType = '';
+
+    public function __construct(public int $id)
+    {
+        parent::__construct('partials/editcard');
+
+        $sql = '
+            SELECT
+                `id`, `name`, `type`, `rarity`, `scryfallId`, `is_changeling`, `cardset`
+            FROM
+                `cards`
+            WHERE
+                `id` = :id';
+        $card = DB::selectOnly($sql, CardDto::class, ['id' => $this->id]);
+
+        $this->cardSet = $card->cardset;
+
+        $this->nameInput = new TextInput('Card Name', 'name', $card->name, 100);
+        $this->typelineInput = new TextInput('Typeline', 'type', $card->type, 100);
+        $this->rarityInput = new TextInput('Rarity', 'rarity', $card->rarity);
+        $this->scryfallIdInput = new TextInput('Scryfall ID', 'sfId', $card->scryfallId, 36);
+        $this->isChangelingInput = new CheckboxInput('Changeling', 'is_changeling', (bool) $card->is_changeling);
+
+        if (str_contains($card->type, 'Creature')) {
+            $this->creatureType = Format::removeTypeCrap($card->type);
+        }
+    }
+}

--- a/gatherling/Views/Components/EditSet.php
+++ b/gatherling/Views/Components/EditSet.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gatherling\Views\Components;
+
+use Gatherling\Data\DB;
+use Gatherling\Models\CardDto;
+use Gatherling\Models\CardSetDto;
+
+class EditSet extends Component
+{
+    public TextInput $setCodeInput;
+    public TextInput $releaseDateInput;
+    public CheckboxInput $standardLegalInput;
+    public CheckboxInput $modernLegalInput;
+    /** @var array<array{id: int, name: string, type: string, rarity: string, count: int, checked: bool, editLink: string}> */
+    public array $cards = [];
+
+    public function __construct(public string $cardSetName)
+    {
+        parent::__construct('partials/editSet');
+        $names = [];
+
+        $sql = '
+            SELECT
+                `code`, `released`, `standard_legal`, `modern_legal`
+            FROM
+                `cardsets`
+            WHERE
+                `name` = :name';
+        $set = DB::selectOnly($sql, CardSetDto::class, ['name' => $cardSetName]);
+
+        $this->setCodeInput = new TextInput('Set Code', 'code', $set->code);
+        $this->releaseDateInput = new TextInput('Release Date', 'released', $set->released);
+        $this->standardLegalInput = new CheckboxInput('Standard Legal', 'standard_legal', (bool) $set->standard_legal);
+        $this->modernLegalInput = new CheckboxInput('Modern Legal', 'modern_legal', (bool) $set->modern_legal);
+
+        $sql = '
+            SELECT
+                `id`, `name`, `type`, `rarity`, `scryfallId`, COUNT(*) AS `count`
+            FROM
+                `cards`
+            LEFT JOIN
+                `deckcontents` ON `cards`.`id` = `deckcontents`.`card`
+            WHERE
+                `cardset` = :cardset';
+        $cards = DB::select($sql, CardDto::class, ['cardset' => $cardSetName]);
+
+        $names = [];
+        foreach ($cards as $card) {
+            $checked = in_array($card->name, $names) && $card->count == 0;
+            $names[] = $card->name;
+            $this->cards[] = [
+                'id' => $card->id,
+                'name' => $card->name,
+                'type' => $card->type,
+                'rarity' => $card->rarity,
+                'count' => $card->count,
+                'checked' => $checked,
+                'editLink' => 'cardscp.php?view=edit_card&id=' . rawurlencode((string) $card->id),
+            ];
+        }
+    }
+}

--- a/gatherling/Views/Components/SetList.php
+++ b/gatherling/Views/Components/SetList.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gatherling\Views\Components;
+
+use Gatherling\Data\DB;
+use Gatherling\Models\CardSetDto;
+
+class SetList extends Component
+{
+    /** @var array<array{name: string, editLink: string, code: string|null, released: string, type: string, lastUpdated: string|null, count: int}> */
+    public array $sets = [];
+
+    public function __construct()
+    {
+        parent::__construct('partials/setList');
+        $sql = '
+            SELECT
+                cs.name, cs.code, cs.released, cs.type, cs.last_updated, COUNT(*) AS `count`
+            FROM
+                cardsets AS cs
+            LEFT JOIN
+                cards AS c ON cs.name = c.cardset
+            GROUP BY
+                cs.name
+            ORDER BY
+                cs.name';
+        $sets = DB::select($sql, CardSetDto::class);
+        foreach ($sets as $set) {
+            $this->sets[] = [
+                'name' => $set->name,
+                'editLink' => 'cardscp.php?view=edit_set&set=' . rawurlencode($set->name),
+                'code' => $set->code,
+                'released' => $set->released,
+                'type' => $set->type,
+                'lastUpdated' => $set->last_updated,
+                'count' => $set->count,
+            ];
+        }
+    }
+}

--- a/gatherling/Views/Pages/CardsAdmin.php
+++ b/gatherling/Views/Pages/CardsAdmin.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gatherling\Views\Pages;
+
+use Gatherling\Views\Components\Component;
+
+class CardsAdmin extends Page
+{
+    public string $viewSafe;
+
+    public function __construct(Component $viewComponent)
+    {
+        parent::__construct();
+        $this->title = 'Admin Control Panel';
+        $this->viewSafe = $viewComponent->render();
+    }
+}

--- a/gatherling/Views/Pages/EventForm.php
+++ b/gatherling/Views/Pages/EventForm.php
@@ -9,6 +9,7 @@ use Gatherling\Models\Player;
 use Gatherling\Views\Components\TextInput;
 use Gatherling\Views\Components\NumDropMenu;
 use Gatherling\Views\Components\StringField;
+use Gatherling\Views\Components\CheckboxInput;
 use Gatherling\Views\Components\RoundDropMenu;
 use Gatherling\Views\Components\FormatDropMenu;
 use Gatherling\Views\Components\SeasonDropMenu;
@@ -42,26 +43,18 @@ class EventForm extends EventFrame
     public NumDropMenu $finalRoundsNumDropMenu;
     /** @var array<string, mixed> */
     public array $finalRoundsStructDropMenu;
-    /** @var array<string, mixed> */
-    public array $preregistrationAllowedCheckbox;
+    public CheckboxInput $preregistrationAllowedCheckbox;
     public TextInput $lateEntryLimitField;
-    /** @var array<string, mixed> */
-    public array $playerReportedResultsCheckbox;
+    public CheckboxInput $playerReportedResultsCheckbox;
     public TextInput $registrationCapField;
-    /** @var array<string, mixed> */
-    public array $deckPrivacyCheckbox;
-    /** @var array<string, mixed> */
-    public array $finalsListPrivacyCheckbox;
-    /** @var array<string, mixed> */
-    public array $playerReportedDrawsCheckbox;
-    /** @var array<string, mixed> */
-    public array $privateEventCheckbox;
+    public CheckboxInput $deckPrivacyCheckbox;
+    public CheckboxInput $finalsListPrivacyCheckbox;
+    public CheckboxInput $playerReportedDrawsCheckbox;
+    public CheckboxInput $privateEventCheckbox;
     /** @var array<string, mixed> */
     public array $clientDropMenu;
-    /** @var array<string, mixed> */
-    public ?array $finalizeEventCheckbox;
-    /** @var array<string, mixed> */
-    public ?array $eventActiveCheckbox;
+    public ?CheckboxInput $finalizeEventCheckbox;
+    public ?CheckboxInput $eventActiveCheckbox;
     public ?RoundDropMenu $currentRoundDropMenu;
     /** @var ?array<string, mixed> */
     public ?array $trophyField;
@@ -125,21 +118,21 @@ class EventForm extends EventFrame
         $mainRoundsStructDropMenu = structDropMenuArgs('mainstruct', $event->mainstruct);
         $finalRoundsNumDropMenu = new NumDropMenu('finalrounds', '- No. of Rounds -', 10, $event->finalrounds, 0);
         $finalRoundsStructDropMenu = structDropMenuArgs('finalstruct', $event->finalstruct);
-        $preregistrationAllowedCheckbox = checkboxInputArgs('Allow Pre-Registration', 'prereg_allowed', (bool) $event->prereg_allowed, null);
+        $preregistrationAllowedCheckbox = new CheckboxInput('Allow Pre-Registration', 'prereg_allowed', (bool) $event->prereg_allowed, null);
         $lateEntryLimitField = new TextInput('Late Entry Limit', 'late_entry_limit', $event->late_entry_limit, 4, 'The event host may still add players after this round.');
-        $playerReportedResultsCheckbox = checkboxInputArgs('Allow Players to Report Results', 'player_reportable', (bool) $event->player_reportable);
+        $playerReportedResultsCheckbox = new CheckboxInput('Allow Players to Report Results', 'player_reportable', (bool) $event->player_reportable);
         $registrationCapField = new TextInput('Player initiatied registration cap', 'prereg_cap', $event->prereg_cap, 4, 'The event host may still add players beyond this limit. 0 is disabled.', null);
-        $deckPrivacyCheckbox = checkboxInputArgs('Deck List Privacy', 'private_decks', (bool) $event->private_decks);
-        $finalsListPrivacyCheckbox = checkboxInputArgs('Finals List Privacy', 'private_finals', (bool) $event->private_finals);
-        $playerReportedDrawsCheckbox = checkboxInputArgs('Allow Player Reported Draws', 'player_reported_draws', (bool) $event->player_reported_draws, 'This allows players to report a draw result for matches.');
-        $privateEventCheckbox = checkboxInputArgs('Private Event', 'private', (bool) $event->private, 'This event is invisible to non-participants');
+        $deckPrivacyCheckbox = new CheckboxInput('Deck List Privacy', 'private_decks', (bool) $event->private_decks);
+        $finalsListPrivacyCheckbox = new CheckboxInput('Finals List Privacy', 'private_finals', (bool) $event->private_finals);
+        $playerReportedDrawsCheckbox = new CheckboxInput('Allow Player Reported Draws', 'player_reported_draws', (bool) $event->player_reported_draws, 'This allows players to report a draw result for matches.');
+        $privateEventCheckbox = new CheckboxInput('Private Event', 'private', (bool) $event->private, 'This event is invisible to non-participants');
         $clientDropMenu = clientDropMenuArgs('client', $event->client);
 
         $finalizeEventCheckbox = $eventActiveCheckbox = $currentRoundDropMenu = $trophyField = null;
         $showCreateNextEvent = $showCreateNextSeason = false;
         if ($edit) {
-            $finalizeEventCheckbox = checkboxInputArgs('Finalize Event', 'finalized', (bool) $event->finalized);
-            $eventActiveCheckbox = checkboxInputArgs('Event Active', 'active', (bool) $event->active);
+            $finalizeEventCheckbox = new CheckboxInput('Finalize Event', 'finalized', (bool) $event->finalized);
+            $eventActiveCheckbox = new CheckboxInput('Event Active', 'active', (bool) $event->active);
             $currentRoundDropMenu = new RoundDropMenu($event, $event->current_round);
             $trophyField = trophyFieldArgs($event);
             $nextEventName = sprintf('%s %d.%02d', $event->series, $event->season, $event->number + 1);

--- a/gatherling/lib_form_helper.php
+++ b/gatherling/lib_form_helper.php
@@ -8,6 +8,7 @@ use Gatherling\Models\Standings;
 use Gatherling\Views\TemplateHelper;
 use Gatherling\Views\Components\Submit;
 use Gatherling\Views\Components\TextInput;
+use Gatherling\Views\Components\CheckboxInput;
 use Gatherling\Views\Components\TimeZoneDropMenu;
 
 require_once 'lib.php';
@@ -19,20 +20,7 @@ function textInput(string $label, string $name, mixed $value = '', int $size = 0
 
 function checkboxInput(string $label, string $name, bool $isChecked = false, ?string $reminderText = null): string
 {
-    $args = checkboxInputArgs($label, $name, $isChecked, $reminderText);
-
-    return TemplateHelper::render('partials/checkboxInput', $args);
-}
-
-/** @return array<string, string|bool|null> */
-function checkboxInputArgs(string $label, string $name, bool $isChecked = false, ?string $reminderText = null): array
-{
-    return [
-        'name'         => $name,
-        'label'        => $label,
-        'isChecked'    => $isChecked,
-        'reminderText' => $reminderText,
-    ];
+    return (new CheckboxInput($label, $name, $isChecked, $reminderText))->render();
 }
 
 function print_file_input(string $label, string $name): void

--- a/gatherling/templates/cardsAdmin.mustache
+++ b/gatherling/templates/cardsAdmin.mustache
@@ -1,0 +1,22 @@
+<div class="grid_10 suffix_1 prefix_1">
+    <div id="gatherling_main" class="box">
+        <div class="uppertitle">Admin Control Panel</div>
+        <center>
+
+            Welcome to the Database Viewer!<br />
+
+            <table>
+                <tr>
+                    <td colspan="2" align="center">
+                        <a href="cardscp.php?view=list_sets">List Card Sets</a>
+                        | <a href="admincp.php?view">Back to AdminCP</a>
+                    </td>
+                </tr>
+            </table>
+
+            {{{viewSafe}}}
+
+        </center>
+        <div class="clear"></div>
+    </div>
+</div>

--- a/gatherling/templates/partials/editCard.mustache
+++ b/gatherling/templates/partials/editCard.mustache
@@ -1,0 +1,19 @@
+<h4>Editing '{{id}}' ({{cardSet}})</h4>
+
+<form action="cardscp.php" method="post">
+    <input type="hidden" name="view" value="edit_card" />
+    <input type="hidden" name="id" value="{{id}}" />
+    <input type="hidden" name="action" value="modify_card" />
+    <table>
+        {{#nameInput}}{{> textInput}}{{/nameInput}}
+        {{#typelineInput}}{{> textInput}}{{/typelineInput}}
+        {{#rarityInput}}{{> textInput}}{{/rarityInput}}
+        {{#scryfallIdInput}}{{> textInput}}{{/scryfallIdInput}}
+        {{#isChangelingInput}}{{> checkboxInput}}{{/isChangelingInput}}
+    </table>
+    <input class="inputbutton" type="submit" name="mode" value="Update Card" />
+</form>
+
+{{#creatureType}}
+    Calculated Tribe(s): {{creatureType}}
+{{/creatureType}}

--- a/gatherling/templates/partials/editSet.mustache
+++ b/gatherling/templates/partials/editSet.mustache
@@ -1,0 +1,43 @@
+<h4>Editing '{{cardSetName}}'</h4>
+
+<form action="cardscp.php" method="post">
+    <table>
+        <input type="hidden" name="view" value="edit_set" />
+        <input type="hidden" name="set" value="{{cardSetName}}" />
+        <input type="hidden" name="action" value="modify_set" />
+
+        <table>
+
+            {{#setCodeInput}}{{> textInput}}{{/setCodeInput}}
+            {{#releaseDateInput}}{{> textInput}}{{/releaseDateInput}}
+            {{#standardLegalInput}}{{> checkboxInput}}{{/standardLegalInput}}
+            {{#modernLegalInput}}{{> checkboxInput}}{{/modernLegalInput}}
+
+            <tr>
+                <th>ID</th>
+                <th>Name</th>
+                <th>Type</th>
+                <th>Rarity</th>
+                <th># of Decks</th>
+                <th>Delete</th>
+            </tr>
+
+            {{#cards}}
+                <tr>
+                    <td>{{id}}</td>
+                    <td>{{name}}</td>
+                    <td>{{type}}</td>
+                    <td>{{rarity}}</td>
+                    <td>{{count}}</td>
+                    <td>
+                        <input type="checkbox" name="delentries[]" value="{{id}}"{{#checked}} checked="yes"{{/checked}} />
+                    </td>
+                    <td>
+                        <a href="{{editLink}}">Edit</a>
+                    </td>
+                </tr>
+            {{/cards}}
+
+    </table>
+    <input class="inputbutton" type="submit" name="mode" value="Modify Set" />
+</form>

--- a/gatherling/templates/partials/setList.mustache
+++ b/gatherling/templates/partials/setList.mustache
@@ -1,0 +1,20 @@
+<table>
+    <tr>
+        <th>Name</th>
+        <th>Code</th>
+        <th>Release Date</th>
+        <th>Set Type</th>
+        <th># Cards</th>
+        <th>Last Updated</th>
+    </tr>
+    {{#sets}}
+        <tr>
+            <td><a href="{{editLink}}">{{name}}</a></td>
+            <td>{{code}}</td>
+            <td>{{released}}</td>
+            <td>{{type}}</td>
+            <td>{{count}}</td>
+            <td>{{lastUpdated}}</td>
+        </tr>
+    {{/sets}}
+</table>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2011,51 +2011,6 @@ parameters:
 			path: gatherling/bootstrap.php
 
 		-
-			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: gatherling/cardscp.php
-
-		-
-			message: "#^Cannot access property \\$error on mysqli_stmt\\|false\\.$#"
-			count: 1
-			path: gatherling/cardscp.php
-
-		-
-			message: "#^Cannot call method bind_param\\(\\) on mysqli_stmt\\|false\\.$#"
-			count: 5
-			path: gatherling/cardscp.php
-
-		-
-			message: "#^Cannot call method bind_result\\(\\) on mysqli_stmt\\|false\\.$#"
-			count: 4
-			path: gatherling/cardscp.php
-
-		-
-			message: "#^Cannot call method close\\(\\) on mysqli_stmt\\|false\\.$#"
-			count: 4
-			path: gatherling/cardscp.php
-
-		-
-			message: "#^Cannot call method execute\\(\\) on mysqli_stmt\\|false\\.$#"
-			count: 6
-			path: gatherling/cardscp.php
-
-		-
-			message: "#^Cannot call method fetch\\(\\) on mysqli_stmt\\|false\\.$#"
-			count: 4
-			path: gatherling/cardscp.php
-
-		-
-			message: "#^Part \\$count \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
-			count: 2
-			path: gatherling/cardscp.php
-
-		-
-			message: "#^Part \\$set \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
-			count: 2
-			path: gatherling/cardscp.php
-
-		-
 			message: "#^Cannot access property \\$name on Gatherling\\\\Models\\\\Event\\|null\\.$#"
 			count: 1
 			path: gatherling/deck.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -132,7 +132,7 @@ parameters:
 
 		-
 			message: "#^Cannot call method bind_param\\(\\) on mysqli_stmt\\|false\\.$#"
-			count: 21
+			count: 20
 			path: gatherling/Models/Deck.php
 
 		-
@@ -147,7 +147,7 @@ parameters:
 
 		-
 			message: "#^Cannot call method execute\\(\\) on mysqli_stmt\\|false\\.$#"
-			count: 22
+			count: 21
 			path: gatherling/Models/Deck.php
 
 		-
@@ -1232,7 +1232,7 @@ parameters:
 
 		-
 			message: "#^Cannot call method bind_param\\(\\) on mysqli_stmt\\|false\\.$#"
-			count: 21
+			count: 20
 			path: gatherling/Models/Series.php
 
 		-
@@ -1242,12 +1242,12 @@ parameters:
 
 		-
 			message: "#^Cannot call method close\\(\\) on mysqli_stmt\\|false\\.$#"
-			count: 21
+			count: 20
 			path: gatherling/Models/Series.php
 
 		-
 			message: "#^Cannot call method execute\\(\\) on mysqli_stmt\\|false\\.$#"
-			count: 23
+			count: 22
 			path: gatherling/Models/Series.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -228,6 +228,14 @@
       <code><![CDATA[$options]]></code>
     </PossiblyUnusedProperty>
   </file>
+  <file src="gatherling/Views/Components/CheckboxInput.php">
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$isChecked]]></code>
+      <code><![CDATA[$label]]></code>
+      <code><![CDATA[$name]]></code>
+      <code><![CDATA[$reminderText]]></code>
+    </PossiblyUnusedProperty>
+  </file>
   <file src="gatherling/Views/Components/DeckLink.php">
     <PossiblyUnusedProperty>
       <code><![CDATA[$deckLink]]></code>
@@ -242,6 +250,29 @@
       <code><![CDATA[$name]]></code>
       <code><![CDATA[$options]]></code>
     </PossiblyUnusedProperty>
+  </file>
+  <file src="gatherling/Views/Components/EditCard.php">
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$cardSet]]></code>
+      <code><![CDATA[$creatureType]]></code>
+      <code><![CDATA[$isChangelingInput]]></code>
+      <code><![CDATA[$nameInput]]></code>
+      <code><![CDATA[$rarityInput]]></code>
+      <code><![CDATA[$scryfallIdInput]]></code>
+      <code><![CDATA[$typelineInput]]></code>
+    </PossiblyUnusedProperty>
+  </file>
+  <file src="gatherling/Views/Components/EditSet.php">
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$cardSetName]]></code>
+      <code><![CDATA[$modernLegalInput]]></code>
+      <code><![CDATA[$releaseDateInput]]></code>
+      <code><![CDATA[$setCodeInput]]></code>
+      <code><![CDATA[$standardLegalInput]]></code>
+    </PossiblyUnusedProperty>
+    <UnusedVariable>
+      <code><![CDATA[$names]]></code>
+    </UnusedVariable>
   </file>
   <file src="gatherling/Views/Components/ErrorMessage.php">
     <PossiblyUnusedProperty>
@@ -556,6 +587,11 @@
       <code><![CDATA[$name]]></code>
     </PossiblyUnusedProperty>
   </file>
+  <file src="gatherling/Views/Pages/CardsAdmin.php">
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$viewSafe]]></code>
+    </PossiblyUnusedProperty>
+  </file>
   <file src="gatherling/Views/Pages/DeckDownload.php">
     <PossiblyUnusedProperty>
       <code><![CDATA[$maindeckCards]]></code>
@@ -604,14 +640,6 @@
       <code><![CDATA[$yearDropMenu]]></code>
     </PossiblyUnusedProperty>
     <UndefinedFunction>
-      <code><![CDATA[checkboxInputArgs('Allow Player Reported Draws', 'player_reported_draws', (bool) $event->player_reported_draws, 'This allows players to report a draw result for matches.')]]></code>
-      <code><![CDATA[checkboxInputArgs('Allow Players to Report Results', 'player_reportable', (bool) $event->player_reportable)]]></code>
-      <code><![CDATA[checkboxInputArgs('Allow Pre-Registration', 'prereg_allowed', (bool) $event->prereg_allowed, null)]]></code>
-      <code><![CDATA[checkboxInputArgs('Deck List Privacy', 'private_decks', (bool) $event->private_decks)]]></code>
-      <code><![CDATA[checkboxInputArgs('Event Active', 'active', (bool) $event->active)]]></code>
-      <code><![CDATA[checkboxInputArgs('Finalize Event', 'finalized', (bool) $event->finalized)]]></code>
-      <code><![CDATA[checkboxInputArgs('Finals List Privacy', 'private_finals', (bool) $event->private_finals)]]></code>
-      <code><![CDATA[checkboxInputArgs('Private Event', 'private', (bool) $event->private, 'This event is invisible to non-participants')]]></code>
       <code><![CDATA[getObjectVarsCamelCase($event)]]></code>
       <code><![CDATA[selectInputArgs('K-Value', 'kvalue', $names, $kvalue)]]></code>
       <code><![CDATA[timeDropMenuArgs($hour, $minutes)]]></code>
@@ -884,15 +912,6 @@
     <InvalidGlobal>
       <code><![CDATA[global $CONFIG;]]></code>
     </InvalidGlobal>
-  </file>
-  <file src="gatherling/cardscp.php">
-    <InvalidGlobal>
-      <code><![CDATA[global $errormsg;]]></code>
-      <code><![CDATA[global $hasError;]]></code>
-    </InvalidGlobal>
-    <UnusedForeachValue>
-      <code><![CDATA[$playername]]></code>
-    </UnusedForeachValue>
   </file>
   <file src="gatherling/config.php">
     <UnusedVariable>


### PR DESCRIPTION
- **Add declare strict types anywhere it was missing**
- **Lint**
- **Rule to remind us to declare strict types in lint**
- **Do not use leading undescore to indicate visisbility, per PSR-12 (and phpcs)**
- **camelCase not snake_case as per PSR-12**
- **Rename some funcs in camelCase in line with PSR-12 coding standard**
- **Document the too-clever-by-half fallthrough, phpcs insists**
- **Rename funcs in camelCase as per PSR-12 coding standard**
- **Rename functions in camelCase for PSR-12 compatibility, ignore config.php**
- **Refactor the last of the snake_case func names to camelCase for PSR-12**
- **Let the phpstan baseline know about some refactorings**
- **Switch to PSR-12-style string concatenation, update phpcs rules**
- **Move .phpcs.xml to phpcs.xml**
- **Banish a few more echos**
- **Improve phpstan baseline after recent fixes**
- **Convert cardscp to be a Page**
