### PR TITLE
Band aid for a league result reporting issue

### DIFF
--- a/gatherling/Models/Entry.php
+++ b/gatherling/Models/Entry.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gatherling\Models;
 
 use Exception;
+use Gatherling\Exceptions\NotFoundException;
 use Gatherling\Views\TemplateHelper;
 
 class Entry
@@ -98,7 +99,7 @@ class Entry
         $stmt->bind_result($deckid, $this->medal, $this->ignored, $this->drop_round, $this->initial_byes, $this->initial_seed);
 
         if ($stmt->fetch() == null) {
-            throw new Exception('Entry for ' . $playername . ' in ' . $event_id . ' not found');
+            throw new NotFoundException('Entry for ' . $playername . ' in ' . $event_id . ' not found');
         }
         $stmt->close();
 

--- a/gatherling/Models/Event.php
+++ b/gatherling/Models/Event.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Gatherling\Models;
 
 use Exception;
+use Gatherling\Log;
 use Gatherling\Data\DB;
-use Gatherling\Views\Components\ReportLink;
+use Gatherling\Exceptions\NotFoundException;
 
 class Event
 {
@@ -698,9 +699,13 @@ class Event
 
     public function removeEntry(string $playername): bool
     {
-        $entry = new Entry($this->id, $playername);
-
-        return $entry->removeEntry();
+        try {
+            $entry = new Entry($this->id, $playername);
+            return $entry->removeEntry();
+        } catch (NotFoundException $e) {
+            Log::info("Tried to remove $playername from {$this->name} but no entry was found.");
+            return true;
+        }
     }
 
     public function addPlayer(string $playername): bool

--- a/gatherling/report.php
+++ b/gatherling/report.php
@@ -308,7 +308,11 @@ function print_verify_resultForm(string $report, int $match_id, string $player, 
     echo "<input name=\"match_id\" type=\"hidden\" value=\"{$match_id}\" />\n";
     echo "<input name=\"player\" type=\"hidden\" value=\"{$player}\" />\n";
     echo "<input name=\"mode\" type=\"hidden\" value=\"submit_result\" />\n";
-    echo "<input name=\"submit\" type=\"submit\" value=\"Go Back and Correct\" />\n";
+    // It would be nice if this functionality worked for league matches
+    // where there is no match_id, but it currently does not so don't show it.
+    if ($match_id) {
+        echo "<input name=\"submit\" type=\"submit\" value=\"Go Back and Correct\" />\n";
+    }
     echo "</form>\n";
     echo "</td> </tr> \n";
     echo "<tr> <td colspan=\"2\" class=\"buttons\">\n";


### PR DESCRIPTION
The behavior here is to take you back to print_submit_resultForm which isn't
even used for league reporting (in a league report the first player can only
report that they have won, to avoid a race condition with both players
reporting separately). So even if there were a match_id or something else to key
off this isn't taking you to the right place.

For sure we can do better here but for now we just hide a button that leads you
astray.

In the pre-type safety world this was not a PHP error. But probably very weird
and pointless things happened when you submitted the resulting form. So I'm
going to say this is a very minor win for the new way of doing things.
