### PR TITLE
Return the series select on seriescp back to action

### DIFF
--- a/gatherling/seriescp.php
+++ b/gatherling/seriescp.php
@@ -91,7 +91,7 @@ function main(): void
 
     $view = post()->optionalString('view') ?? get()->optionalString('view') ?? 'settings';
 
-    if ($view != 'no_view') {
+    if ($view == 'no_view') {
         $orientationComponent = new NullComponent();
     } elseif (count($playerSeries) > 1) {
         $orientationComponent = new OrganizerSelect(server()->string('PHP_SELF'), $playerSeries, $activeSeriesName);

--- a/gatherling/templates/partials/organizerSelect.mustache
+++ b/gatherling/templates/partials/organizerSelect.mustache
@@ -1,4 +1,6 @@
-<form action="{{action}}" method="get">
-    {{#seriesDropMenu}}{{> dropMenu}}{{/seriesDropMenu}}
-    <input class="inputbutton" type="submit" value="Select Series">
-</form>
+<center>
+    <form action="{{action}}" method="get">
+        {{#seriesDropMenu}}{{> dropMenu}}{{/seriesDropMenu}}
+        <input class="inputbutton" type="submit" value="Select Series">
+    </form>
+</center>


### PR DESCRIPTION
I should have negated this boolean logic when I refactored.

At some point we will remove all the old-fashioned HTML but for now <center>
is what we use.
