### PR TITLE
Don't try to add or validate a new match unless player A or player B are set

### DIFF
--- a/gatherling/event.php
+++ b/gatherling/event.php
@@ -485,7 +485,7 @@ function updateMatches(): void
     $res = post()->string('newmatchresult', '');
     $rnd = post()->int('newmatchround');
 
-    if ($pA || $pB || $res || $rnd) {
+    if ($pA || $pB) {
         [$pAWins, $pBWins, $res] = match ($res) {
             '2-0' => [2, 0, 'A'],
             '2-1' => [2, 1, 'A'],


### PR DESCRIPTION
This form sometimes has round and result set in hidden inputs so we'll just
check if they set player A or player B to determine if they are trying to add
a match.

This does mean that if you can see all the dropdowns and you fill out round and
result but neither player you will get a silent nothing happening. But (a) that
was true before, and (b) why would you do that. So I think it's ok and better
than saying "Player A is required" to people doing things like deleting matches
and not trying to add a match at all!
