### PR TITLE
Avoid 500 when adding player to an event that is already entered but has no deck

### DIFF
--- a/gatherling/Models/Entry.php
+++ b/gatherling/Models/Entry.php
@@ -48,10 +48,10 @@ class Entry
 
     public static function findByEventAndPlayer(int $event_id, string $playername): ?self
     {
-        $sql = 'SELECT deck FROM entries WHERE event_id = :event_id AND player = :player';
+        $sql = 'SELECT player FROM entries WHERE event_id = :event_id AND player = :player';
         $params = ['event_id' => $event_id, 'player' => $playername];
-        $deckId = db()->optionalInt($sql, $params);
-        if (!$deckId) {
+        $player = db()->optionalString($sql, $params);
+        if (!$player) {
             return null;
         }
         return new self($event_id, $playername);

--- a/gatherling/templates/partials/allDecks.mustache
+++ b/gatherling/templates/partials/allDecks.mustache
@@ -1,22 +1,17 @@
 <p>Decks marked with a <font color="#FF0000">*</font> are not legal under current format.</p>
 
-<div class="alpha grid_6">
-    <div id="gatherling_lefthalf">
-        <table width="275">
-            <tr>
-                <td colspan="3"><b>{{upPlayer}}'S DECKS</td>
-            </tr>
-            {{#decks}}
-            <tr>
-                <td width="20">{{#medalSrc}}<img alt="Medal" src="{{medalSrc}}" style="border-width: 0">{{/medalSrc}}</td>
-                <td width="20">{{recordString}}</td>
-                <td>{{#deckLink}}{{> deckLink}}{{/deckLink}}{{^isValid}}<font color="#FF0000">*</font>{{/isValid}}</td>
-                <td align="right"><a href="{{eventLink}}">{{eventName}}</a></td>
-            </tr>
-            {{/decks}}
-        </table>
-    </div>
-</div>
-<div class="omega grid_4">
-    <div id="gatherling_righthalf"></div>
+<div>
+    <table>
+        <tr>
+            <td colspan="3"><b>{{upPlayer}}'S DECKS</b></td>
+        </tr>
+        {{#decks}}
+        <tr>
+            <td>{{#medalSrc}}<img alt="Medal" src="{{medalSrc}}" style="border-width: 0">{{/medalSrc}}</td>
+            <td>{{recordString}}</td>
+            <td>{{#deckLink}}{{> deckLink}}{{/deckLink}}{{^isValid}}<font color="#FF0000">*</font>{{/isValid}}</td>
+            <td align="right"><a href="{{eventLink}}">{{eventName}}</a></td>
+        </tr>
+        {{/decks}}
+    </table>
 </div>


### PR DESCRIPTION
There's no reason to 500 here and in fact this is a regression. This method
used to look for num_rows > 0 rather than requiring an entry for deck. I just
messed it up when cutting it across to new db style.
