### PR TITLE
Temporarily increase the number of events showin on recent_events to fix snafu

### DIFF
--- a/gatherling/api.php
+++ b/gatherling/api.php
@@ -104,7 +104,7 @@ function main(): never
                 FROM events e
                 WHERE e.finalized AND e.start < NOW()
             ORDER BY e.start DESC
-                LIMIT 10';
+                LIMIT 100';
             $eventNames = db()->strings($sql);
             foreach ($eventNames as $eventName) {
                 $event = new Event($eventName);


### PR DESCRIPTION
We had to restore Gatherling from a db backup and we're backfilling missing
events and we want pennydreadfulmagic.com to see them as they are filled so that
they can be scraped.
