### PR TITLE
Switch to CDN for Font Awesome to avoid monthly limits

### DIFF
--- a/gatherling/templates/partials/header.mustache
+++ b/gatherling/templates/partials/header.mustache
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Gatherling | {{ title }}</title>
     <link rel="stylesheet" type="text/css" href="{{ cssLink }}">
-    <script src="https://kit.fontawesome.com/b7c30c664c.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free/js/all.min.js"></script>
     <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/npm/keyrune@latest/css/keyrune.css">
     <script src="//code.jquery.com/jquery-latest.min.js"></script>
 </head>


### PR DESCRIPTION
We've been hitting the 10,000 page view limit on Font Awesome's own CDN but
there is no such limit on jsdelivr that we already use for luxon time display
stuff.

License is MIT so this is fine/not dodgy.
