### PR TITLE
Do not allow entries.deck to be set to NULL if it has a value

### DIFF
--- a/gatherling/Data/sql/migrations/86.sql
+++ b/gatherling/Data/sql/migrations/86.sql
@@ -1,0 +1,9 @@
+CREATE TRIGGER prevent_null_deck
+BEFORE UPDATE ON entries
+FOR EACH ROW
+BEGIN
+    IF OLD.deck IS NOT NULL AND NEW.deck IS NULL THEN
+        SIGNAL SQLSTATE '45000'
+        SET MESSAGE_TEXT = 'Error: Attempt to set entries.deck to NULL';
+    END IF;
+END;

--- a/gatherling/Models/Deck.php
+++ b/gatherling/Models/Deck.php
@@ -87,7 +87,7 @@ class Deck
 
         // Check for created date in entries if it isn't in the decks table
         if (is_null($this->created_date)) {
-            $sql = 'SELECT registered_at FROM entries where deck = :id';
+            $sql = 'SELECT registered_at FROM entries WHERE deck = :id';
             $this->created_date = db()->optionalString($sql, ['id' => $id]);
         }
 


### PR DESCRIPTION
- **Prevent null-ing out a deck in entries via a trigger**
- **Correct case of SQL statement**
