### PR TITLE
Don't show the login box to already-signed-in folks

### DIFF
--- a/gatherling/Views/Pages/Page.php
+++ b/gatherling/Views/Pages/Page.php
@@ -19,7 +19,7 @@ abstract class Page extends TemplateResponse
     public bool $isHost;
     public bool $isOrganizer;
     public bool $isSuper;
-    public string $shortPlayerName = '';
+    public string $playerDisplayName = '';
     public string $versionTagline;
     public string $jsLink;
 
@@ -31,9 +31,9 @@ abstract class Page extends TemplateResponse
         $player = Player::getSessionPlayer();
         if ($player !== null) {
             $username_chars_to_show = 8;
-            $this->shortPlayerName = substr($player->name, 0, $username_chars_to_show);
+            $this->playerDisplayName = substr($player->name, 0, $username_chars_to_show);
             if (strlen($player->name) > $username_chars_to_show) {
-                $this->shortPlayerName = $this->shortPlayerName . '…';
+                $this->playerDisplayName = $this->playerDisplayName . '…';
             }
         }
         $this->isHost = $player?->isHost() ?? false;

--- a/gatherling/templates/home.mustache
+++ b/gatherling/templates/home.mustache
@@ -68,7 +68,7 @@
                 </ul>
             </div>
         {{/playerInfo}}
-        {{^player}}
+        {{^playerDisplayName}}
             <h2 class="uppertitle">Login to Gatherling</h1>
             <form action="login.php" method="post">
                 <table class="form">
@@ -94,7 +94,7 @@
                 <a href="register.php">Need to register?</a><br>
                 <a href="forgot.php">Forgot your password?</a>
             </p>
-        {{/player}}
+        {{/playerDisplayName}}
     </div>
     <div class="box">
         <h2 class="uppertitle">Recent Winners</h1>

--- a/gatherling/templates/partials/menu.mustache
+++ b/gatherling/templates/partials/menu.mustache
@@ -4,12 +4,12 @@
         <li><a href="player.php">Player CP</a></li>
         <li><a href="eventreport.php">Metagame</a></li>
         <li><a href="decksearch.php">Deck Search</a></li>
-        {{#shortPlayerName}}
-            <li class="last"><a href="logout.php">Logout [{{shortPlayerName}}]</a></li>
-        {{/shortPlayerName}}
-        {{^shortPlayerName}}
+        {{#playerDisplayName}}
+            <li class="last"><a href="logout.php">Logout [{{playerDisplayName}}]</a></li>
+        {{/playerDisplayName}}
+        {{^playerDisplayName}}
             <li class="last"><a href="login.php">Login</a></li>
-        {{/shortPlayerName}}
+        {{/playerDisplayName}}
         {{#isHost}}
             <li><a href="event.php">Host CP</a></li>
         {{/isHost}}


### PR DESCRIPTION
This was relying on Page->player that I removed when making the display name
shorter for the logout button in the menu.

It's maybe slightly odd to rely on this truncate version of the username as
the "is signed in or not" indicator, but I renamed it so it makes at least a
little more sense. No point in having a whole extra property just for this I
don't think.
