### PR TITLE
Remove trigger that did not help

### DIFF
--- a/gatherling/Data/sql/migrations/88.sql
+++ b/gatherling/Data/sql/migrations/88.sql
@@ -1,0 +1,1 @@
+DROP TRIGGER prevent_null_deck;


### PR DESCRIPTION
This was supposed to prevent the phenomenon of decks become disassociated from
the relevant tournament entry but somehow it never fired and did not stop it
happening.

So let's not have a trigger that doesn't do anything in the db as the only
trigger this program requires.
